### PR TITLE
fix: a build exception occurred on an older version of JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build with Maven and Upload Artifact
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "oracle"
+          java-version: "17"
+
+      - name: Build with Maven
+        run: mvn clean package -DskipTests
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tabby-vul-finder-jar
+          path: |
+            target/*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>vul.finder</name>
 	<description>vul finder for tabby</description>
 	<properties>
-		<java.version>1.8</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -49,13 +49,12 @@
 	</dependencies>
 
 	<build>
+		<finalName>tabby-vul-finder</finalName>
+
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<finalName>tabby-vul-finder</finalName>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
## Abstract

This pull request has undergone two modifications to adapt to the higher version of JDK for artifact building, and a workflow has been added to GitHub Actions to achieve automatic packaging of `tabby-vul-finder.jar`.

## Packaging Issue

_All the following operations only modified the JDK version used by the project without any additional processing. All builds are completed using the command `mvn clean package`._

1. The following problems occurred when packaging tabby-vul-finder using **Oracle OpenJDK 1.8.0\_461**:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /F:/Github/elabosak233/tabby-vul-finder/src/main/java/tabby/vul/finder/App.java:[3,28] cannot access com.beust.jcommander.JCommander
  bad class file: C:\Users\ElaBosak\.m2\repository\org\jcommander\jcommander\2.0\jcommander-2.0.jar(com/beust/jcommander/JCommander.class)
    class file has wrong version 55.0, should be 52.0
    Please remove or make sure it appears in the correct subdirectory of the classpath.
[INFO] 1 error
[INFO] -------------------------------------------------------------
```

After the search, [jcommander/issues/473](https://github.com/cbeust/jcommander/issues/473) shows the solution to this problem, if need support for JDK 1.8, JCommander shall be downgraded. Considering that the parent project Tabby uses JDK 17, upgrading the project's JDK will be a better choice.

2. If Oracle **OpenJDK 21.0.4** is used, the following problems will occur:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project vul.finder: Fatal error compiling: java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid' -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

3. If **Oracle OpenJDK 17.0.16** is used, the build is successful, but a warning line appears:

```
Parameter 'finalName' is read-only, must not be used in configuration
```

In conclusion, we need to modify the pom.xml as follows:

```xml
<properties>
	<java.version>17</java.version>
</properties>
```

```xml
<build>
	<finalName>tabby-vul-finder</finalName>

	<plugins>
		<plugin>
			<groupId>org.springframework.boot</groupId>
			<artifactId>spring-boot-maven-plugin</artifactId>
		</plugin>
	</plugins>
</build>
```

## Automatic Build

Automated build workflow has been written in `.github/workflows/build.yml`. `tabby-vul-finder.jar` will be built and uploaded to Artifacts section of every runs. It is convenient for those in need to download the artifacts directly.